### PR TITLE
Removed the old QuickStart instructions from the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,8 @@
 Project codename: ***GODZILLA***
 
 ***GODZILLA*** is the Spring WebFlux backend app that services the React client
-app (codenamed ***MUTO***)
+app (codenamed ***MUTO***).
 
-## QuickStart
+## Getting Started
 
-
-### Prerequisites
-
-- Maven (latest - <https://maven.apache.org/download.cgi>)
-- Java 11 (LTS - <https://www.oracle.com/ca-en/java/technologies/javase-downloads.html>)
-
-
-To run the server:
-
-1. Execute the command: `./mvnw package spring-boot:run` in the root directory of the project.
-2. Browse to <http://localhost:8080/> in your web browser.
+To get started with the app, checkout the [Quickstart wiki page](https://github.com/Serum-390/godzilla/wiki).


### PR DESCRIPTION
Also added a link to the QuickStart wiki page.

# Description

Removed the old QuickStart instructions from the README.md in favor of linking to the wiki.

## Link to work item

Closes issue #9 

## How to Test

Check out the README.md, ensure the links are working.
