### PR TITLE
Added dockerfile and build script

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,84 @@
+name: Docker
+
+on:
+  push:
+
+    # Publish `main` as Docker `latest` image.
+    branches:
+      - main
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run tests for any PRs.
+  pull_request:
+
+env:
+  IMAGE_ID: ghcr.io/serum-390/godzilla
+  DOCKER_FILE: docker/godzilla.dockerfile
+
+jobs:
+
+  # Run tests.
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Run tests
+        run: |
+          ./mvnw clean package
+          if [ -f docker-compose.test.yml ]; then
+            docker-compose --file docker-compose.test.yml build
+            docker-compose --file docker-compose.test.yml run sut
+          else
+            docker build . --file $DOCKER_FILE
+          fi
+
+  # Push image to GitHub Packages.
+  push:
+
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Build image
+        run: |
+          ./mvnw clean package
+          docker build . --file $DOCKER_FILE --tag $IMAGE_ID
+
+      - name: Log into registry
+        run: echo "${{ secrets.GODZILLA_OPS_PAT }}" | docker login ghcr.io -u ${{ secrets.GODZILLA_OPS_USERNAME }} --password-stdin
+
+      - name: Push image
+        run: |
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+
+          echo "Pushing image: $IMAGE_ID:$VERSION"
+
+          docker tag $IMAGE_ID $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 Project codename: ***GODZILLA***
 
-***GODZILLA*** is the Spring WebFlux backend app that services the React client
-app (codenamed ***MUTO***).
+Visit the live demo environment here: <https://godzilla.serum-390.app/>
 
 ## Getting Started
 

--- a/docker/build-and-run.sh
+++ b/docker/build-and-run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+PROJECT_ROOT=../
+IMAGE_TAG="ghcr.io/serum-390/godzilla:latest"
+
+build_app() (
+    cd "$PROJECT_ROOT"
+    ./mvnw clean package
+)
+
+build_image() (
+    docker build --tag "$IMAGE_TAG" \
+                 -f "godzilla.dockerfile" \
+                 "$PROJECT_ROOT"
+    docker image prune -f
+)
+
+run_container() {
+    CONTAINER_NAME='godzilla-test'
+    docker container rm -f "$CONTAINER_NAME" && true || true
+    docker run -d \
+               --name "$CONTAINER_NAME" \
+               -p 0.0.0.0:8080:8080 \
+               "$IMAGE_TAG"
+}
+
+main() {
+    build_app
+    build_image
+    run_container
+}
+
+[[ ${BASH_SOURCE[0]} == $0 ]] && main $@

--- a/docker/godzilla.dockerfile
+++ b/docker/godzilla.dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:slim
+
+WORKDIR /home/godzilla
+COPY target/godzilla-*.jar ./
+
+RUN useradd godzilla
+
+USER godzilla
+CMD ["sh", "-c", "java -jar /home/godzilla/godzilla-*.jar"]


### PR DESCRIPTION
# Description

- Adds a minimal dockerfile and a shell script to aid in building the docker image and running the container.
- I also ran the script in this PR to build the docker image for the app, then pushed this image to the github repo as a GitHub Package.
    - What this means is that anyone can now pull the docker image from github (instead of manually building the image) and then run the docker container.  
- You can view the Docker image package in:  "Code" tab of the repo >  right hand side-bar menu > Package > godzilla latest

## Link to work item

Closes #8 
Closes #23 

## How to Test

Run the docker container one of two ways:
1. Pull the premade image from github and spin up a container.
2.  Build the docker image manually using the shell script and dockerfile in this PR. Then spin up a container.

### 1. Pulling from GitHub

Enter the following command to run a new container with the image from GitHub:

```bash
docker run -d --name godzilla-test -p 8080:8080 ghcr.io/serum-390/godzilla:latest
```

#### Explanation

- `docker run`: Creates and starts a new docker container from a given image tag.
- `-d` or `--detach=true`: This option tells docker to run the container in the background, "detached" from our current terminal session (as opposed to running the container interactively, with a tty (terminal) attached to the container).  
- `--name <CONTAINER_NAME>`: Gives a convenient name for our container that we can later refer to when using docker. This name can be whatever you choose.
- `-p <HOST_PORT>:<CONTAINER_PORT>`: This is a port publishing option (hence the '-p'). 1 container = 1 machine, and so containers have their own set of ports in the same way that your local system has its own ports. If we want to make our app available on port 8080 of the local system, then we have to forward the container's port 8080 to our machine's port 8080.
- `ghcr.io/serum-390/godzilla:latestt`: This is the "tag" associated with our docker image - it identifies which container image we want to use to start our container instance.

### 2. Building the image yourself

Included in this PR is a convenient script that:
1. Runs a production build of the app (creating a deployable JAR file).
2. Builds a container image with our JAR file inside it.
3. Spins up a container from that image.

To run the script:

```bash
cd docker
./build-and-run.sh
```