### PR TITLE
41 react router spring

### DIFF
--- a/src/main/app/src/pages/Inventory.js
+++ b/src/main/app/src/pages/Inventory.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const getInventory = async () => {
-  const api = '/inv/';
+  const api = '/api/inv/';
   const got = await fetch(api);
   const json = await got.json();
   return json.inventory || [];

--- a/src/main/java/ca/serum390/godzilla/configuration/ReactRouterForwardFilter.java
+++ b/src/main/java/ca/serum390/godzilla/configuration/ReactRouterForwardFilter.java
@@ -1,0 +1,54 @@
+package ca.serum390.godzilla.configuration;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+
+import reactor.core.publisher.Mono;
+
+
+/**
+ * This {@link WebFilter} component is needed to forward requests to the React
+ * Router routes.
+ */
+@Component
+public class ReactRouterForwardFilter implements WebFilter {
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        if (matchesReactRouterRoute(exchange)) {
+            return forwardToReactRouter(exchange, chain);
+        }
+
+        return chain.filter(exchange);
+    }
+
+    /**
+     * ! NOTE: This is probably not the most effecient way to forward all these
+     * ! requests to the react-router - we are basically checking each and every
+     * ! request to see if it needs to be forwarded to index.html
+     *
+     * @param exchange
+     * @return
+     */
+    private boolean matchesReactRouterRoute(ServerWebExchange exchange) {
+        String path = exchange.getRequest().getURI().getPath();
+        return !path.startsWith("/api/")
+            && !path.startsWith("/resources/")
+            && !path.endsWith(".js")
+            && !path.endsWith(".css")
+            && !path.endsWith(".svg");
+    }
+
+    private Mono<Void> forwardToReactRouter(ServerWebExchange exchange, WebFilterChain chain) {
+        return chain.filter(
+                exchange.mutate()
+                        .request(
+                            exchange.getRequest()
+                                    .mutate()
+                                    .path("/index.html")
+                                    .build()
+                        ).build());
+    }
+}

--- a/src/main/java/ca/serum390/godzilla/configuration/RouteConfig.java
+++ b/src/main/java/ca/serum390/godzilla/configuration/RouteConfig.java
@@ -4,7 +4,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.config.ResourceHandlerRegistry;
 import org.springframework.web.reactive.config.WebFluxConfigurer;
-import org.springframework.web.reactive.function.server.RequestPredicates;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
 import org.springframework.web.reactive.function.server.ServerResponse;
@@ -12,14 +11,16 @@ import org.springframework.web.reactive.function.server.ServerResponse;
 import ca.serum390.godzilla.handlers.HelloHandler;
 import ca.serum390.godzilla.handlers.InventoryHandler;
 
-
 @Configuration
-public class RouteConfig implements WebFluxConfigurer {
+public class RouteConfig implements WebFluxConfigurer { 
 
     @Bean
     public RouterFunction<ServerResponse> route() {
-        return RouterFunctions.route(RequestPredicates.GET("/inv/"), InventoryHandler::getInventory)
-                              .andRoute(RequestPredicates.GET("/hello/"), HelloHandler::helloWorld);
+        return RouterFunctions.route()
+                .path("/api/", builder -> builder
+                    .GET("/inv/", InventoryHandler::getInventory)
+                    .GET("/hello/", HelloHandler::helloWorld))
+                .build();
     }
 
     @Override

--- a/src/main/java/ca/serum390/godzilla/configuration/RouteConfig.java
+++ b/src/main/java/ca/serum390/godzilla/configuration/RouteConfig.java
@@ -12,8 +12,13 @@ import ca.serum390.godzilla.handlers.HelloHandler;
 import ca.serum390.godzilla.handlers.InventoryHandler;
 
 @Configuration
-public class RouteConfig implements WebFluxConfigurer { 
+public class RouteConfig implements WebFluxConfigurer {
 
+    /**
+     * Router using the functional endpoints Spring WebFlux API
+     *
+     * @return A router function bound to the application's RESTful APIs.
+     */
     @Bean
     public RouterFunction<ServerResponse> route() {
         return RouterFunctions.route()
@@ -23,6 +28,9 @@ public class RouteConfig implements WebFluxConfigurer {
                 .build();
     }
 
+    /**
+     * Serve some static resources via /resources/<my_resource>
+     */
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/resources/**")

--- a/src/main/java/ca/serum390/godzilla/controllers/ReactForwardingController.java
+++ b/src/main/java/ca/serum390/godzilla/controllers/ReactForwardingController.java
@@ -1,9 +1,0 @@
-package ca.serum390.godzilla.controllers;
-
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-@RestController
-public class ReactForwardingController {
-
-}

--- a/src/main/java/ca/serum390/godzilla/controllers/ReactForwardingController.java
+++ b/src/main/java/ca/serum390/godzilla/controllers/ReactForwardingController.java
@@ -1,0 +1,9 @@
+package ca.serum390.godzilla.controllers;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ReactForwardingController {
+
+}


### PR DESCRIPTION
# Description

This PR integrates Spring with the React router routes that we have defined in the frontend.

## Link to work item

Closes #41 

## How to Test

1. Run the app:
    ```bash
    mvn clean package
    java -jar target/godzilla-0.0.1-SNAPSHOT.jar
    ```
2. Try to navigate to one of the React router routes directly (i.e. without opening the home page and selecting a view). You can do this by visiting the following URL: <http://localhost:8080/Inventory>

The result is that Spring will forward you to the `react-router` route directly, instead of giving you a 404 error like before.