### PR TITLE
Added the team name to the README.md

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,7 +54,7 @@ jobs:
     # Ensure test job passes before pushing image.
     needs: test
 
-    name: Docker GitHub Packages Update
+    name: GitHub Packages Update
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # godzilla <a href="https://github.com/Serum-390/godzilla/actions?query=workflow%3A%22Maven+build%22"><img src="https://github.com/Serum-390/godzilla/workflows/Maven%20build/badge.svg" alt="Maven Build"></a>
 
+**SOEN-390 Team-16**
+
 Project codename: ***GODZILLA***
 
 Visit the live demo environment here: <https://godzilla.serum-390.app/>

--- a/docker/build-and-run.sh
+++ b/docker/build-and-run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 PROJECT_ROOT=../
 IMAGE_TAG="ghcr.io/serum-390/godzilla:latest"
 
@@ -19,7 +17,7 @@ build_image() (
 
 run_container() {
     CONTAINER_NAME='godzilla-test'
-    docker container rm -f "$CONTAINER_NAME" && true || true
+    docker container rm -f "$CONTAINER_NAME"
     docker run -d \
                --name "$CONTAINER_NAME" \
                -p 0.0.0.0:8080:8080 \


### PR DESCRIPTION
# Description

Instead of renaming the repo, I think it is a better idea to simply add the team
name to the `README.md` - this way the TA can see at a glance what team we are.

Other Changes:
- Removed the `set -e` from the docker build shell script. This command causes
  the script to error out when sourced.
- Changed the name of th GitHub Packages update step in the Docker CI

## Link to work item

Closes #2

## How to Test

This is a minor change. Check out the `README.md` to see the team name added.
